### PR TITLE
Fix module crash on null or undefined input

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 
 
 var escape = module.exports = function escape(string) {
+  if (string === null || string === undefined) return;
   return string.replace(/([&"<>'])/g, function(str, item) {
             return escape.map[item];
           })

--- a/test.js
+++ b/test.js
@@ -5,3 +5,11 @@ test("Characters should be escaped properly", function (t) {
 
     t.equals(escape('" \' < > &'), '&quot; &apos; &lt; &gt; &amp;');
 })
+
+test("Module should not crash on null or undefined input", function (t) {
+    t.plan(3);
+
+    t.equals((escape("")), "");
+    t.doesNotThrow(function(){escape(null);}, TypeError);
+    t.doesNotThrow(function(){escape(undefined);}, TypeError);
+})


### PR DESCRIPTION
This fixes the module crashing with a TypeError due to undefined or null input.Ran into this problem when attempting to convert variable JavaScript object string attributes to a more XML-friendly format. Also added some tests.